### PR TITLE
Claude Opus 4.7の選択肢を一旦コメントアウトして無効化

### DIFF
--- a/amplify/agent/runtime/config.py
+++ b/amplify/agent/runtime/config.py
@@ -3,14 +3,14 @@
 
 def get_model_config(model_type: str = "sonnet") -> dict:
     """モデルタイプに応じた設定を返す"""
-    if model_type == "opus4.7":
-        # Claude Opus 4.7
-        return {
-            "model_id": "us.anthropic.claude-opus-4-7",
-            "cache_prompt": "default",
-            "cache_tools": "default",
-        }
-    elif model_type == "opus":
+    # if model_type == "opus4.7":
+    #     # Claude Opus 4.7
+    #     return {
+    #         "model_id": "us.anthropic.claude-opus-4-7",
+    #         "cache_prompt": "default",
+    #         "cache_tools": "default",
+    #     }
+    if model_type == "opus":
         # Claude Opus 4.6
         return {
             "model_id": "us.anthropic.claude-opus-4-6-v1",

--- a/src/components/Chat/types.ts
+++ b/src/components/Chat/types.ts
@@ -1,4 +1,4 @@
-export type ModelType = 'sonnet' | 'opus' | 'opus4.7';
+export type ModelType = 'sonnet' | 'opus' /* | 'opus4.7' */;
 
 export interface ModelOption {
   value: ModelType;
@@ -9,7 +9,7 @@ export interface ModelOption {
 // モデル選択肢の定義（ここを増減するだけでUIが自動対応）
 export const MODEL_OPTIONS: ModelOption[] = [
   { value: 'sonnet', label: 'Claude Sonnet 4.6', shortLabel: 'Sonnet 4.6' },
-  { value: 'opus4.7', label: 'Claude Opus 4.7', shortLabel: 'Opus 4.7' },
+  // { value: 'opus4.7', label: 'Claude Opus 4.7', shortLabel: 'Opus 4.7' },
 ];
 
 export interface ReferenceFile {


### PR DESCRIPTION
## 概要

昨日追加したClaude Opus 4.7のモデル選択肢を一旦コメントアウトして無効化。

## 変更内容

- `src/components/Chat/types.ts`: `ModelType` の `'opus4.7'` と `MODEL_OPTIONS` のOpus 4.7エントリをコメントアウト
- `amplify/agent/runtime/config.py`: `get_model_config` の `opus4.7` 分岐をコメントアウト

復活時は各コメントを外すだけでOKです。

## テスト観点

- [ ] モデルセレクターにOpus 4.7が表示されないこと
- [ ] Sonnet 4.6のデフォルト動作に影響がないこと